### PR TITLE
Bash util scripts for docker-compose & certbot automation + minor bug fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ docker exec -it db /manual_setup.sh
 ### Using bash helper scripts
 1. For convinence create the following symlink
     ```
-    ln -s bash_utils/country_server_console_wrapper.sh /usr/local/bin/country_server_console_wrapper
+    # ln -s bash_utils/country_server_console_wrapper.sh /usr/local/bin/country_server_console_wrapper
+    # chmod a+x /usr/local/bin/country_server_console_wrapper
     ```
 1. The following args should be passed as env variables
     ```
@@ -182,14 +183,17 @@ docker exec -it db /manual_setup.sh
      [optional] SERVICE - name of docker service e.g. odk, nest, nginx
     ```
 #### Example usage in crontab:
-```
-@reboot USERNAME=ec2-user COUNTRY_NAME=car ACTION='up -d' /usr/local/bin/country_server_console_wrapper  >> /var/log/country_startup.log 2>&1
-```
+1. Create directory `/home/ec2-user/cron_jobs/`
+1. 
+    ```
+    @reboot USERNAME=ec2-user COUNTRY_NAME=car ACTION='up -d' /usr/local/bin/country_server_console_wrapper  >> /home/ec2-user/cron_jobs/country_server_init.log 2>&1
+    ```
 #### Helper script for ssl cert reneval
-1. Add certbot-auto in `/usr/local/sbin`
+1. Create directory `/home/ec2-user/cron_jobs/`
+1. Install certbot-auto and add it in `/usr/local/sbin`
 1. Add ssl_renval helper script to **root** crontab 
     ```
-    2 30 * * *  USERNAME=ec2-user COUNTRY_NAME=car /home/ec2-user/meerkat_country_server/bash_utils/ssl_reneval.sh >> /var/log/ssl_reneval.log 2>&1
+    2 30 * * *  USERNAME=ec2-user COUNTRY_NAME=car /home/ec2-user/meerkat_country_server/bash_utils/ssl_reneval.sh >> /home/ec2-user/cron_jobs/ssl_reneval.log 2>&1
     ```
 ### Logs
 Logs for continous WAL backup can be seen id db container logs.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,28 @@ Manual configuration for initial backup is required with:
 ```bash
 docker exec -it db /manual_setup.sh
 ```
-
+### Using bash helper scripts
+1. For convinence create the following symlink
+    ```
+    ln -s bash_utils/country_server_console_wrapper.sh /usr/local/bin/country_server_console_wrapper
+    ```
+1. The following args should be passed as env variables
+    ```
+     USERNAME - name of the user in whom home dir meerkat_country_server is checked out
+     COUNTRY_NAME - name of deployed country e.g. car or demo
+     ACTION - docker-compose action you'd like to use. e.g. 'up -d', 'stop', 'start', 'rm -v'
+     [optional] SERVICE - name of docker service e.g. odk, nest, nginx
+    ```
+#### Example usage in crontab:
+```
+@reboot USERNAME=ec2-user COUNTRY_NAME=car ACTION='up -d' /usr/local/bin/country_server_console_wrapper  >> /var/log/country_startup.log 2>&1
+```
+#### Helper script for ssl cert reneval
+1. Add certbot-auto in `/usr/local/sbin`
+1. Add ssl_renval helper script to **root** crontab 
+    ```
+    2 30 * * *  USERNAME=ec2-user COUNTRY_NAME=car /home/ec2-user/meerkat_country_server/bash_utils/ssl_reneval.sh >> /var/log/ssl_reneval.log 2>&1
+    ```
 ### Logs
 Logs for continous WAL backup can be seen id db container logs.
 Weekly base backups will be logged inside the container under `/cron.log`

--- a/bash_utils/country_server_console_wrapper.sh
+++ b/bash_utils/country_server_console_wrapper.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+### The following args should be passed as env variables
+# USERNAME - name of the user in whom home dir meerkat_country_server is checked out
+# COUNTRY_NAME - name of deployed country e.g. car or demo
+# ACTION - docker-compose action you'd like to use. e.g. 'up -d', 'stop', 'start', 'rm -v'
+# [optional] SERVICE - name of docker service e.g. odk, nest, nginx
+#
+# Example usage in crontab:
+# @reboot USERNAME=ec2-user COUNTRY_NAME=car ACTION='up -d' country_server_console_wrapper.sh  >> /var/log/country_startup.log 2>&1
+
+
+/usr/local/bin/docker-compose -f /home/${USERNAME}/meerkat_country_server/docker-compose.yml -f /home/${USERNAME}/meerkat_${COUNTRY_NAME}/nest/${COUNTRY_NAME} ${SERVICE} ${ACTION}

--- a/bash_utils/country_server_console_wrapper.sh
+++ b/bash_utils/country_server_console_wrapper.sh
@@ -10,4 +10,5 @@ set -x
 # @reboot USERNAME=ec2-user COUNTRY_NAME=car ACTION='up -d' country_server_console_wrapper.sh  >> /var/log/country_startup.log 2>&1
 
 
+cd /home/${USERNAME}/meerkat_country_server/
 /usr/local/bin/docker-compose -f /home/${USERNAME}/meerkat_country_server/docker-compose.yml -f /home/${USERNAME}/meerkat_${COUNTRY_NAME}/nest/${COUNTRY_NAME}.yml ${ACTION} ${SERVICE}

--- a/bash_utils/country_server_console_wrapper.sh
+++ b/bash_utils/country_server_console_wrapper.sh
@@ -10,4 +10,4 @@
 # @reboot USERNAME=ec2-user COUNTRY_NAME=car ACTION='up -d' country_server_console_wrapper.sh  >> /var/log/country_startup.log 2>&1
 
 
-/usr/local/bin/docker-compose -f /home/${USERNAME}/meerkat_country_server/docker-compose.yml -f /home/${USERNAME}/meerkat_${COUNTRY_NAME}/nest/${COUNTRY_NAME} ${SERVICE} ${ACTION}
+/usr/local/bin/docker-compose -f /home/${USERNAME}/meerkat_country_server/docker-compose.yml -f /home/${USERNAME}/meerkat_${COUNTRY_NAME}/nest/${COUNTRY_NAME} ${ACTION} ${SERVICE}

--- a/bash_utils/country_server_console_wrapper.sh
+++ b/bash_utils/country_server_console_wrapper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -x
 ### The following args should be passed as env variables
 # USERNAME - name of the user in whom home dir meerkat_country_server is checked out
 # COUNTRY_NAME - name of deployed country e.g. car or demo
@@ -10,4 +10,4 @@
 # @reboot USERNAME=ec2-user COUNTRY_NAME=car ACTION='up -d' country_server_console_wrapper.sh  >> /var/log/country_startup.log 2>&1
 
 
-/usr/local/bin/docker-compose -f /home/${USERNAME}/meerkat_country_server/docker-compose.yml -f /home/${USERNAME}/meerkat_${COUNTRY_NAME}/nest/${COUNTRY_NAME} ${ACTION} ${SERVICE}
+/usr/local/bin/docker-compose -f /home/${USERNAME}/meerkat_country_server/docker-compose.yml -f /home/${USERNAME}/meerkat_${COUNTRY_NAME}/nest/${COUNTRY_NAME}.yml ${ACTION} ${SERVICE}

--- a/bash_utils/ssl_reneval.sh
+++ b/bash_utils/ssl_reneval.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 ### Script for updating ssl certs for country repo nginx
 # TO BE RUN BY root
 #
@@ -8,7 +7,9 @@ set -x
 # COUNTRY_NAME - name of deployed country e.g. car or demo
 #
 echo "$(date) ------- Running SSL reneval."
+set -x
 ACTION=stop SERVICE=nginx country_server_console_wrapper
 certbot-auto renew
 ACTION=start SERVICE=nginx country_server_console_wrapper
+set +x
 echo "$(date) ------- SSL reneval finished."

--- a/bash_utils/ssl_reneval.sh
+++ b/bash_utils/ssl_reneval.sh
@@ -7,7 +7,8 @@ set -x
 # USERNAME - name of the user in whom home dir meerkat_country_server is checked out
 # COUNTRY_NAME - name of deployed country e.g. car or demo
 #
-
+echo "$(date) ------- Running SSL reneval."
 ACTION=stop SERVICE=nginx country_server_console_wrapper
 certbot-auto renew
 ACTION=start SERVICE=nginx country_server_console_wrapper
+echo "$(date) ------- SSL reneval finished."

--- a/bash_utils/ssl_reneval.sh
+++ b/bash_utils/ssl_reneval.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+### Script for updating ssl certs for country repo nginx
+# TO BE RUN BY root
+#
+### The following args should be passed as env variables for country_server_console_wrapper script
+# USERNAME - name of the user in whom home dir meerkat_country_server is checked out
+# COUNTRY_NAME - name of deployed country e.g. car or demo
+#
+
+ACTION=stop SERVICE=nginx country_server_console_wrapper
+certbot-auto renew
+ACTION=start SERVICE=nginx country_server_console_wrapper

--- a/bash_utils/ssl_reneval.sh
+++ b/bash_utils/ssl_reneval.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 ### Script for updating ssl certs for country repo nginx
 # TO BE RUN BY root
 #

--- a/nginx/config/sites-available/odk_aggregate_http
+++ b/nginx/config/sites-available/odk_aggregate_http
@@ -7,6 +7,7 @@ server {
   location /.well-known {
          root /usr/local/nginx/html;
   }
+
   location / {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Server $host;

--- a/nginx/config/sites-available/odk_aggregate_https.template
+++ b/nginx/config/sites-available/odk_aggregate_https.template
@@ -4,10 +4,6 @@ server {
     charset     utf-8;
     client_max_body_size 500M;
 
-    charset     utf-8;
-    large_client_header_buffers 4 32k;
-    client_max_body_size 500M;
-
     ssl on;
     ssl_certificate     ${SSL_CERTIFICATE};
     ssl_certificate_key ${SSL_CERTIFICATE_KEY};

--- a/nginx/run.sh
+++ b/nginx/run.sh
@@ -5,6 +5,7 @@ envsubst < /etc/nginx/sites-available/odk_aggregate_https.template | tee /etc/ng
 
 echo "---- Creating symlinks ----"
 mkdir -p /etc/nginx/sites-enabled
+rm -f /etc/nginx/sites-enabled/odk_aggregate_http*
 ln -s /etc/nginx/sites-available/odk_aggregate_http /etc/nginx/sites-enabled/odk_aggregate_http
 ln -s /etc/nginx/sites-available/odk_aggregate_https /etc/nginx/sites-enabled/odk_aggregate_https
 


### PR DESCRIPTION
1. Fixed broken nginx config by removing duplicate lines from nginx/config/sites-available/odk_aggregate_https.template
2. Fixed a bug of nginx container not recreating properly.
3. Added bash helper scripts in `bash_utils` to wrap up docker-compose command and automate ssl cert update. More info in the README.md